### PR TITLE
add talk board to nav

### DIFF
--- a/access/index.html
+++ b/access/index.html
@@ -20,6 +20,7 @@
             <li><a href="../explore">Explore content</a></li>
             <li><a class="active" href="../access">Access API</a></li>
             <li><a href="../documentation">Read documentation</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/guardian-api-talk">Help Forum</a></li>
         </ul>
 
 	  	<h1> Get a Key </h1>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -27,6 +27,7 @@
             <li><a href="../explore">Explore content</a></li>
             <li><a href="../access">Access API</a></li>
             <li><a class="active" href="../documentation">Read documentation</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/guardian-api-talk">Help Forum</a></li>
         </ul>
 
         <div class="pushed">

--- a/documentation/item.html
+++ b/documentation/item.html
@@ -27,6 +27,7 @@
             <li><a href="../explore">Explore content</a></li>
             <li><a href="../access">Access API</a></li>
             <li><a class="active" href="../documentation">Read documentation</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/guardian-api-talk">Help Forum</a></li>
         </ul>
 
         <div class="pushed">

--- a/documentation/search.html
+++ b/documentation/search.html
@@ -27,6 +27,7 @@
             <li><a href="../explore">Explore content</a></li>
             <li><a href="../access">Access API</a></li>
             <li><a class="active" href="../documentation">Read documentation</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/guardian-api-talk">Help Forum</a></li>
         </ul>
 
         <div class="pushed">

--- a/documentation/section.html
+++ b/documentation/section.html
@@ -27,6 +27,7 @@
             <li><a href="../explore">Explore content</a></li>
             <li><a href="../access">Access API</a></li>
             <li><a class="active" href="../documentation">Read documentation</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/guardian-api-talk">Help Forum</a></li>
         </ul>
 
         <div class="pushed">

--- a/documentation/tag.html
+++ b/documentation/tag.html
@@ -27,6 +27,7 @@
             <li><a href="../explore">Explore content</a></li>
             <li><a href="../access">Access API</a></li>
             <li><a class="active" href="../documentation">Read documentation</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/guardian-api-talk">Help Forum</a></li>
         </ul>
 
         <div class="pushed">

--- a/explore/index.html
+++ b/explore/index.html
@@ -18,6 +18,7 @@
             <li><a class="active" href="../explore">Explore content</a></li>
             <li><a href="../access">Access API</a></li>
             <li><a href="../documentation">Read documentation</a></li>
+            <li><a href="https://groups.google.com/forum/#!forum/guardian-api-talk">Help Forum</a></li>
         </ul>
 
         <iframe src="http://content-a-loadbala-fovyc7zr32pc-240268148.eu-west-1.elb.amazonaws.com" width="100%" height="100%" seamless="true" marginwidth="0" marginheight="0" frameborder="0" vspace="0" hspace="0" allowtransparency="false" style="background: #FFFFFF;"> </iframe>


### PR DESCRIPTION
Make talk board more prominent, implements suggestion of Alistair Jardine.
![screen shot 2014-07-18 at 11 10 56](https://cloud.githubusercontent.com/assets/1764158/3624939/b08f9866-0e63-11e4-937f-23a5d0879e43.png)
