### PR TITLE
remove .html extension from links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ npm install -g gulp
 cd build
 gulp
 ```
+
+## Viewing documentation locally
+We use the content negotiation on GitHub Pages to resolve paths without a file extension
+e.g. `tag.html` is resolved as `tag` by GitHub Pages.
+When running locally to view the file add back the file extension e.g. `http://localhost:18080/documentation/tag.html`

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -37,10 +37,10 @@
             <li><a href="../documentation" class="active">Read documentation</a></li>
             <li class="sep">›</li>
             <li class="active"><a href="./" class="active">Getting Started</a></li>
-            <li><a href="search.html" >Content</a></li>
-            <li><a href="tag.html" >Tags</a></li>
-            <li><a href="section.html">Sections</a></li>
-            <li><a href="item.html">Single Item</a></li>
+            <li><a href="./search" >Content</a></li>
+            <li><a href="./tag" >Tags</a></li>
+            <li><a href="./section">Sections</a></li>
+            <li><a href="./item">Single Item</a></li>
         </ul>
 
         <div>

--- a/documentation/item.html
+++ b/documentation/item.html
@@ -36,11 +36,11 @@
         <ul class="nav2">
             <li><a href="../documentation" class="active">Read documentation</a></li>
             <li class="sep">›</li>
-            <li class="active"><a href="item.html" class="active">Single Item</a></li>
+            <li class="active"><a href="./item" class="active">Single Item</a></li>
             <li><a href="./">Getting Started</a></li>
-            <li><a href="search.html" >Content</a></li>
-            <li><a href="tag.html" >Tags</a></li>
-            <li><a href="section.html">Sections</a></li>
+            <li><a href="./search" >Content</a></li>
+            <li><a href="./tag" >Tags</a></li>
+            <li><a href="./section">Sections</a></li>
         </ul>
 
         <div>

--- a/documentation/md/index.md
+++ b/documentation/md/index.md
@@ -40,7 +40,7 @@ Here the `q` parameter filters the results to only those that include that searc
 
 ### Tags
 
-The [tags endpoint](tag.html) (`/tags`) returns all tags in the API. All Guardian content is manually categorised using these tags, of which there are nearly 20,000.
+The [tags endpoint](./tag) (`/tags`) returns all tags in the API. All Guardian content is manually categorised using these tags, of which there are nearly 20,000.
 
 A tag is a piece of data that we use to categorise our content. We use many different tags so understanding what they mean is important, and with new ones being added all the time you'll want to make sure to keep up to date with the changes.
 
@@ -65,7 +65,7 @@ Finally, tags have types:
 
 ### Sections
 
-The [sections endpoint](section.html)(`/sections`) returns all sections in the API.
+The [sections endpoint](./section)(`/sections`) returns all sections in the API.
 
 We use sections to logically group our content.
 
@@ -77,7 +77,7 @@ If you request `apiUrl` value, the API would recognise them as single item reque
 
 ### Single item
 
-The [single item endpoint](item.html) returns all the data we have for a given single item id. Here the term 'item' refers to either a piece of content, a tag, or a section. The item endpoint matches the paths on theguardian.com. So by replacing the domain theguardian.com with beta.content.guardianapis.com you can see the data associated.
+The [single item endpoint](./item) returns all the data we have for a given single item id. Here the term 'item' refers to either a piece of content, a tag, or a section. The item endpoint matches the paths on theguardian.com. So by replacing the domain theguardian.com with beta.content.guardianapis.com you can see the data associated.
 
 For example:
 

--- a/documentation/search.html
+++ b/documentation/search.html
@@ -36,11 +36,11 @@
         <ul class="nav2">
             <li><a href="../documentation" class="active">Read documentation</a></li>
             <li class="sep">›</li>
-            <li class="active"><a href="search.html" class="active">Content</a></li>
+            <li class="active"><a href="./search" class="active">Content</a></li>
             <li><a href="./">Getting Started</a></li>
-            <li><a href="tag.html" >Tags</a></li>
-            <li><a href="section.html">Sections</a></li>
-            <li><a href="item.html">Single Item</a></li>
+            <li><a href="./tag" >Tags</a></li>
+            <li><a href="./section">Sections</a></li>
+            <li><a href="./item">Single Item</a></li>
         </ul>
 
         <div>

--- a/documentation/section.html
+++ b/documentation/section.html
@@ -36,11 +36,11 @@
         <ul class="nav2">
             <li><a href="../documentation" class="active">Read documentation</a></li>
             <li class="sep">›</li>
-            <li class="active"><a href="section.html" class="active">Sections</a></li>
+            <li class="active"><a href="./section" class="active">Sections</a></li>
             <li><a href="./">Getting Started</a></li>
-            <li><a href="search.html">Content</a></li>
-            <li><a href="tag.html" >Tags</a></li>
-            <li><a href="item.html">Single Item</a></li>
+            <li><a href="./search">Content</a></li>
+            <li><a href="./tag" >Tags</a></li>
+            <li><a href="./item">Single Item</a></li>
         </ul>
 
         <div>

--- a/documentation/tag.html
+++ b/documentation/tag.html
@@ -36,11 +36,11 @@
         <ul class="nav2">
             <li><a href="../documentation" class="active">Read documentation</a></li>
             <li class="sep">›</li>
-            <li class="active"><a href="tag.html" class="active">Tags</a></li>
+            <li class="active"><a href="./tag" class="active">Tags</a></li>
             <li><a href="./">Getting Started</a></li>
-            <li><a href="search.html">Content</a></li>
-            <li><a href="section.html">Sections</a></li>
-            <li><a href="item.html">Single Item</a></li>
+            <li><a href="./search">Content</a></li>
+            <li><a href="./section">Sections</a></li>
+            <li><a href="./item">Single Item</a></li>
         </ul>
 
         <div>


### PR DESCRIPTION
Remove .html from file extension to better future-proof site. 
Added note to readme to explain how to run locally.
