### PR TITLE
Changed the advertised calls per second

### DIFF
--- a/access/index.html
+++ b/access/index.html
@@ -36,10 +36,10 @@
             <h1>Developer</h1>
             <ul>
                 <li>Free</li>
-                <li>Up to 25 calls per second</li>
+                <li>Up to 12 calls per second</li>
                 <li>Up to 5,000 calls per day</li>
                 <li>Access to article text</li>
-                <li>Access to over 1,600,000 pieces of content</li>
+                <li>Access to over 1,740,000 pieces of content</li>
             </ul>
         </div>
 


### PR DESCRIPTION
The default requests per second was incorrect on the website.   Just added this small amendment
