### PR TITLE
Remove usage of Google Analytics

### DIFF
--- a/documentation/edition.html
+++ b/documentation/edition.html
@@ -108,21 +108,11 @@
          </div>
           <div class="row">
             <div class="col-sm-12">
-                <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+                <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
              </div>
          </div>
      </div>
   </footer>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52456141-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
-  </script>
 
 </body>
 </html>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -101,21 +101,10 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/openplatform">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>
 </footer>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52456141-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
-  </script>
-
 </body>
 </html>

--- a/documentation/item.html
+++ b/documentation/item.html
@@ -102,21 +102,10 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/openplatform">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>
 </footer>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52456141-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
-  </script>
-
 </body>
 </html>

--- a/documentation/search.html
+++ b/documentation/search.html
@@ -102,21 +102,10 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/openplatform">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>
 </footer>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52456141-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
-  </script>
-
 </body>
 </html>

--- a/documentation/section.html
+++ b/documentation/section.html
@@ -103,21 +103,10 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/openplatform">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>
 </footer>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52456141-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
-  </script>
-
 </body>
 </html>

--- a/documentation/tag.html
+++ b/documentation/tag.html
@@ -103,21 +103,10 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/openplatform">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>
 </footer>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52456141-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
-  </script>
-
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -139,20 +139,10 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/openplatform">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>
 </footer>
-    <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-     m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-52456141-1', 'auto');
-    ga('require', 'displayfeatures');
-    ga('send', 'pageview');
-    </script>
-   </body>
+</body>
 </html>


### PR DESCRIPTION
## What does this change?

Remove usage of Google Analytics as it is not used anymore. It was added long time ago before `GDPR` and `PECR` to quickly understand who was using this website.  As the purpose of this website is mostly to document our API and commercial offer we do, we don't need such analytics capability.

@jfsoul   