### PR TITLE
Updates the open platform docs in anticipation of the fourth Edition

### DIFF
--- a/documentation/md/edition.md
+++ b/documentation/md/edition.md
@@ -7,37 +7,53 @@ Editions
 ## Example response
 
     {
-      "response": {
-        "status": "ok",
-        "userTier": "free",
-        "total": 3,
-        "results": [
-          {
-            "webTitle": "new guardian australia front page",
-            "path": "au",
-            "edition": "AU",
-            "id": "au",
-            "webUrl": "https://www.theguardian.com/au",
-            "apiUrl": "https://content.guardianapis.com/au"
-          },
-          {
-            "webTitle": "new guardian us front page",
-            "path": "us",
-            "edition": "US",
-            "id": "us",
-            "webUrl": "https://www.theguardian.com/us",
-            "apiUrl": "https://content.guardianapis.com/us"
-          },
-          {
-            "webTitle": "new guardian uk front page",
-            "path": "uk",
-            "edition": "UK",
-            "id": "uk",
-            "webUrl": "https://www.theguardian.com/uk",
-            "apiUrl": "https://content.guardianapis.com/uk"
-          }
-        ]
-      }
+		"response": {
+			"status": "ok",
+			"userTier": "internal",
+			"total": 5,
+			"results": [
+				{
+					"id": "au",
+					"path": "au",
+					"edition": "AU",
+					"webTitle": "new guardian australia front page",
+					"webUrl": "https://www.theguardian.com/au",
+					"apiUrl": "https://content.guardianapis.com/au"
+				},
+				{
+					"id": "europe",
+					"path": "europe",
+					"edition": "Europe",
+					"webTitle": "new guardian europe front page",
+					"webUrl": "https://www.theguardian.com/europe",
+					"apiUrl": "https://content.guardianapis.com/europe"
+				},
+				{
+					"id": "international",
+					"path": "international",
+					"edition": "International",
+					"webTitle": "new guardian international front page",
+					"webUrl": "https://www.theguardian.com/international",
+					"apiUrl": "https://content.guardianapis.com/international"
+				},
+				{
+					"id": "uk",
+					"path": "uk",
+					"edition": "UK",
+					"webTitle": "new guardian uk front page",
+					"webUrl": "https://www.theguardian.com/uk",
+					"apiUrl": "https://content.guardianapis.com/uk"
+				},
+				{
+					"id": "us",
+					"path": "us",
+					"edition": "US",
+					"webTitle": "new guardian us front page",
+					"webUrl": "https://www.theguardian.com/us",
+					"apiUrl": "https://content.guardianapis.com/us"
+				}
+			]
+		}
     }
 
 Field  | Description | Type |  |

--- a/documentation/md/index.md
+++ b/documentation/md/index.md
@@ -116,7 +116,7 @@ If you request `apiUrl` value, the API would recognise them as single item reque
 
 The [editions endpoint](./edition) (`/editions`) returns all editions in the API.
 
-Editions are the different front main pages of the Guardian site we have. At current we have editions for the United Kingdom, the United States and Australia.
+Editions are the regionalised front pages of the Guardian site. At current we have editions for the United Kingdom, the United States, Australia and Europe.
 
 ### Single item
 


### PR DESCRIPTION
Very small updates, actually tested locally which is new for me ;-)

## What does this change?

New example JSON for Editions endpoint output.

## How to test

Has been tested locally, should be okay just to merge.

## How can we measure success?

Any consumers of the /editions endpoint are not surprised.

## Have we considered potential risks?

They seem negligible 

## Images

<img width="944" alt="image" src="https://user-images.githubusercontent.com/479167/191477304-c3f53736-4aba-46fd-ad14-2fd823308ec5.png">

<img width="924" alt="image" src="https://user-images.githubusercontent.com/479167/191477411-7c47eed4-114c-49a1-aa77-139213c01b34.png">

## Accessibility
No changes