### PR TITLE
README update: npm install command to install all deps, not just gulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ open-platform-site
 ### Install gulp
 ```
 cd build
-npm install gulp
+npm install
 ```
 
 ### Run gulp


### PR DESCRIPTION
Just a small README tweak to the build instructions, so that it installs all the dependencies, not just gulp.