### PR TITLE
Usertier, Copyright-year, SingleItem-page changes

### DIFF
--- a/access/index.html
+++ b/access/index.html
@@ -119,7 +119,7 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/gdndevelopers">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>

--- a/documentation/edition.html
+++ b/documentation/edition.html
@@ -107,7 +107,7 @@
          </div>
           <div class="row">
             <div class="col-sm-12">
-                <p>© 2021 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+                <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
              </div>
          </div>
      </div>

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -100,7 +100,7 @@
               <li><a href="https://www.theguardian.com/info/series/engineering-blog">Engineering Blog</a></li>
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
           </ul>
-          <p>© 2021 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>

--- a/documentation/item.html
+++ b/documentation/item.html
@@ -101,7 +101,7 @@
               <li><a href="https://www.theguardian.com/info/series/engineering-blog">Engineering Blog</a></li>
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
           </ul>
-          <p>© 2021 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>

--- a/documentation/md/edition.md
+++ b/documentation/md/edition.md
@@ -9,7 +9,7 @@ Editions
     {
 		"response": {
 			"status": "ok",
-			"userTier": "internal",
+			"userTier": "developer",
 			"total": 5,
 			"results": [
 				{

--- a/documentation/md/edition.md
+++ b/documentation/md/edition.md
@@ -76,5 +76,5 @@ Field  | Description | Type |  |
 | `q`  | Return edition based on the query term specified | *String* | e.g. UK         |
 
 ## Example
-[https://content.guardianapis.com/editions?q=uk&api-key=test](http://content.guardianapis.com/editions?q=uk)
+[https://content.guardianapis.com/editions?q=uk&api-key=test](http://content.guardianapis.com/editions?q=uk&api-key=test)
 

--- a/documentation/md/item.md
+++ b/documentation/md/item.md
@@ -8,23 +8,27 @@ Single Item
 
 ### Query
 
-`https://content.guardianapis.com/business/2014/feb/18/uk-inflation-falls-below-bank-england-target`
+`https://content.guardianapis.com/sport/2022/oct/07/cricket-jos-buttler-primed-for-england-comeback-while-phil-salt-stays-focused?api-key=test`
 
 ### Response
 
     {
       "response":{
         "status":"ok",
-        "userTier":"free",
+        "userTier":"developer",
         "total":1,
         "content":{
-          "id":"business/2014/feb/18/uk-inflation-falls-below-bank-england-target",
-          "sectionId":"business",
-          "sectionName":"Business",
-          "webPublicationDate":"2014-02-18T11:02:45Z",
-          "webTitle":"UK inflation falls below Bank of England's 2% target",
-          "webUrl":"https://www.theguardian.com/business/2014/feb/18/uk-inflation-falls-below-bank-england-target",
-          "apiUrl":"https://content.guardianapis.com/business/2014/feb/18/uk-inflation-falls-below-bank-england-target"
+          "id": "sport/2022/oct/07/cricket-jos-buttler-primed-for-england-comeback-while-phil-salt-stays-focused",
+          "type": "article",
+          "sectionId": "sport",
+          "sectionName": "Sport",
+          "webPublicationDate": "2022-10-07T12:00:01Z",
+          "webTitle": "Jos Buttler primed for England comeback while Phil Salt stays focused",
+          "webUrl": "https://www.theguardian.com/sport/2022/oct/07/cricket-jos-buttler-primed-for-england-comeback-while-phil-salt-stays-focused",
+          "apiUrl": "https://content.guardianapis.com/sport/2022/oct/07/cricket-jos-buttler-primed-for-england-comeback-while-phil-salt-stays-focused",
+          "isHosted": false,
+          "pillarId": "pillar/sport",
+          "pillarName": "Sport"
         }
       }
     }
@@ -39,18 +43,17 @@ Field  | Description | Type |  |
 
 ### Query term
 
-Field  | Description | Type | Accepted values |
------- | ----------- | ---- |-----------------|
- `id`  |  The ID for an item, such as a piece of content, is the path to that item on the site. By replacing the domain with content.guardianapis.com you get the API URL for that piece of content | *String * | 
-
+| Field | Description                                                                                                                                                                               | Type      | Accepted values |
+|-------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-----------------|
+| `id`  | The ID for an item, such as a piece of content, is the path to that item on the site. By replacing the domain with content.guardianapis.com you get the API URL for that piece of content | *String * |                 |
 
 ### Additional information
 
-Field  | Description | Type | Accepted values |
------- | ----------- | ---- |-----------------|
-`show-story-package` | When `true` display a list of content that is in the has been identified as being about the same story as the requested content item. When a content item is in a package the `hasStoryPackage` field has a value of `true` | *Boolean* | true \| false
-`show-editors-picks` | When `true` display a list of content that is chosen by editors on tags, sections and the home page. This content list represents the main list of content found on the equivalent path on the site | *Boolean* | true \| false
-`show-most-viewed` | When `true` display most viewed content. For overall most viewed set `id` to '/', for section most viewed set `id` to the section id
-`show-related` | Content items can show a set of 'related' content. When `true` returns content items related to the main content item  | *Boolean* | true \| false
+| Field                | Description                                                                                                                                                                                                                 | Type      | Accepted values |
+|----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------|-----------------|
+| `show-story-package` | When `true` display a list of content that is in the has been identified as being about the same story as the requested content item. When a content item is in a package the `hasStoryPackage` field has a value of `true` | *Boolean* | true \          | false
+| `show-editors-picks` | When `true` display a list of content that is chosen by editors on tags, sections and the home page. This content list represents the main list of content found on the equivalent path on the site                         | *Boolean* | true \          | false
+| `show-most-viewed`   | When `true` display most viewed content. For overall most viewed set `id` to '/', for section most viewed set `id` to the section id                                                                                        |           |                 |
+| `show-related`       | Content items can show a set of 'related' content. When `true` returns content items related to the main content item                                                                                                       | *Boolean* | true \          | false
 
 

--- a/documentation/md/section.md
+++ b/documentation/md/section.md
@@ -9,7 +9,7 @@ Sections
     {
     "response": {
     "status": "ok",
-    "userTier": "free",
+    "userTier": "developer",
     "total": 1,
     "results": [
       {
@@ -45,9 +45,9 @@ Field  | Description | Type |  |
 
 ### Query term
 
-Name  | Description | Type | Accepted values
------ | ----------- | ---- | ---------------
-`q` | Return section based on the query term specified | *String* | e.g. business
+| Name | Description                                      | Type     | Accepted values |
+|------|--------------------------------------------------|----------|-----------------|
+| `q`  | Return section based on the query term specified | *String* | e.g. business   |
 
 ## Example
 [https://content.guardianapis.com/sections?q=business&api-key=test](http://content.guardianapis.com/sections?q=business)

--- a/documentation/md/section.md
+++ b/documentation/md/section.md
@@ -50,5 +50,5 @@ Field  | Description | Type |  |
 | `q`  | Return section based on the query term specified | *String* | e.g. business   |
 
 ## Example
-[https://content.guardianapis.com/sections?q=business&api-key=test](http://content.guardianapis.com/sections?q=business)
+[https://content.guardianapis.com/sections?q=business&api-key=test](http://content.guardianapis.com/sections?q=business&api-key=test)
 

--- a/documentation/search.html
+++ b/documentation/search.html
@@ -101,7 +101,7 @@
               <li><a href="https://www.theguardian.com/info/series/engineering-blog">Engineering Blog</a></li>
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
           </ul>
-          <p>© 2021 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>

--- a/documentation/section.html
+++ b/documentation/section.html
@@ -102,7 +102,7 @@
               <li><a href="https://www.theguardian.com/info/series/engineering-blog">Engineering Blog</a></li>
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
           </ul>
-          <p>© 2021 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>

--- a/documentation/tag.html
+++ b/documentation/tag.html
@@ -102,7 +102,7 @@
               <li><a href="https://www.theguardian.com/info/series/engineering-blog">Engineering Blog</a></li>
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
           </ul>
-          <p>© 2021 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>

--- a/explore/index.html
+++ b/explore/index.html
@@ -82,7 +82,7 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/gdndevelopers">Follow Us</a></li>
           </ul>
-          <p>© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/gdndevelopers">Follow Us</a></li>
           </ul>
-          <p>© 2020 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>


### PR DESCRIPTION
## What has change?

Content changes:
api-key usertier to have "developer" for feed,
copyright year to 2022,
single-item page to have latest example and

and small fix:
example links were not worked as intentional

## How to test

via running on localhost

## How can we measure success?

To test if viable contents are present on site or not