### PR TITLE
Small change to update the date in the footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
               <li><a href="https://developers.theguardian.com/join-the-team.html">Join Us</a></li>
               <li><a href="https://twitter.com/gdndevelopers">Follow Us</a></li>
           </ul>
-          <p>© 2022 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
+          <p>© 2023 Guardian News and Media Limited or its affiliated companies. All rights reserved.</p>
        </div>
    </div>
 </div>


### PR DESCRIPTION
A small change to update the copyright year on the Open Platform site.  Changing the date from 2022, to 2023.  We should probably add some logic to automatically update this at some point.  I will add this to the backlog.
