### PR TITLE
Add new community client links

### DIFF
--- a/documentation/md/index.md
+++ b/documentation/md/index.md
@@ -146,16 +146,16 @@ We maintain and support officially only one client, the [Scala client library](h
 
 However, clients for other languages have been created by the developer community and you can find these on github:
 
- * Golang: [github.com/guardian/gocapiclient](https://github.com/guardian/gocapiclient)
- * Haskell: [github.com/guardian/content-api-haskell-client](https://github.com/guardian/content-api-haskell-client)
- * Java: 
+ * **Golang** [github.com/guardian/gocapiclient](https://github.com/guardian/gocapiclient)
+ * **Haskell** [github.com/guardian/content-api-haskell-client](https://github.com/guardian/content-api-haskell-client)
+ * **Java** 
    * (Antonio Matarrese) [github.com/matarrese/content-api-the-guardian](https://github.com/matarrese/content-api-the-guardian)
    * (Omoniyi Omotoso) [github.com/niyiomotoso/the-guardian-api-java-client](https://github.com/niyiomotoso/the-guardian-api-java-client)
- * Javascript: (Kalob Porter) [github.com/PorterK/GuardianJSClient](https://github.com/PorterK/GuardianJSClient)
- * PHP: (Omoniyi Omotoso) [github.com/niyiomotoso/the-guardian-api-php-client](https://github.com/niyiomotoso/the-guardian-api-php-client)
- * Python: (Prabhath Kiran) [github.com/prabhath6/theguardian-api-python](https://github.com/prabhath6/theguardian-api-python)
- * Ruby: (Tom ten Thij) [github.com/tomtt/contentapi-ruby](https://github.com/tomtt/contentapi-ruby)
- * Rust: (Mario Savarese) [github.com/MarSavar/aletheia](https://github.com/MarSavar/aletheia)
+ * **Javascript** (Kalob Porter) [github.com/PorterK/GuardianJSClient](https://github.com/PorterK/GuardianJSClient)
+ * **PHP** (Omoniyi Omotoso) [github.com/niyiomotoso/the-guardian-api-php-client](https://github.com/niyiomotoso/the-guardian-api-php-client)
+ * **Python** (Prabhath Kiran) [github.com/prabhath6/theguardian-api-python](https://github.com/prabhath6/theguardian-api-python)
+ * **Ruby** (Tom ten Thij) [github.com/tomtt/contentapi-ruby](https://github.com/tomtt/contentapi-ruby)
+ * **Rust** (Mario Savarese) [github.com/MarSavar/aletheia](https://github.com/MarSavar/aletheia)
 
 ## Support
 

--- a/documentation/md/index.md
+++ b/documentation/md/index.md
@@ -144,7 +144,7 @@ The Content API is also available over HTTPS at [https://content.guardianapis.co
 
 We maintain and support officially only one client, the [Scala client library](https://github.com/guardian/content-api-scala-client).
 
-However, clients for other languages have been created by the developer community, and you can find these on github:
+However, clients for other languages have been created by the developer community and you can find these on github:
 
  * Golang: [github.com/guardian/gocapiclient](https://github.com/guardian/gocapiclient)
  * Haskell: [github.com/guardian/content-api-haskell-client](https://github.com/guardian/content-api-haskell-client)

--- a/documentation/md/index.md
+++ b/documentation/md/index.md
@@ -144,18 +144,18 @@ The Content API is also available over HTTPS at [https://content.guardianapis.co
 
 We maintain and support officially only one client, the [Scala client library](https://github.com/guardian/content-api-scala-client).
 
-There are however other clients, supported by the community:
+However, clients for other languages have been created by the developer community, and you can find these on github:
 
- * [Haskell client library](https://github.com/guardian/content-api-haskell-client)
- * [Ruby client library](https://github.com/tomtt/contentapi-ruby)
- * [Python client library](https://github.com/prabhath6/theguardian-api-python)
- * [Javascript client library](https://github.com/PorterK/GuardianJSClient)
- * [Golang client library](https://github.com/guardian/gocapiclient)
- * [.NET client library](https://github.com/l7ssha/GuardianNet)
- * [Java client library](https://github.com/matarrese/content-api-the-guardian)
- * [Rust client library](https://github.com/MarSavar/aletheia)
-
-
+ * Golang: [github.com/guardian/gocapiclient](https://github.com/guardian/gocapiclient)
+ * Haskell: [github.com/guardian/content-api-haskell-client](https://github.com/guardian/content-api-haskell-client)
+ * Java: 
+   * (Antonio Matarrese) [github.com/matarrese/content-api-the-guardian](https://github.com/matarrese/content-api-the-guardian)
+   * (Omoniyi Omotoso) [github.com/niyiomotoso/the-guardian-api-java-client](https://github.com/niyiomotoso/the-guardian-api-java-client)
+ * Javascript: (Kalob Porter) [github.com/PorterK/GuardianJSClient](https://github.com/PorterK/GuardianJSClient)
+ * PHP: (Omoniyi Omotoso) [github.com/niyiomotoso/the-guardian-api-php-client](https://github.com/niyiomotoso/the-guardian-api-php-client)
+ * Python: (Prabhath Kiran) [github.com/prabhath6/theguardian-api-python](https://github.com/prabhath6/theguardian-api-python)
+ * Ruby: (Tom ten Thij) [github.com/tomtt/contentapi-ruby](https://github.com/tomtt/contentapi-ruby)
+ * Rust: (Mario Savarese) [github.com/MarSavar/aletheia](https://github.com/MarSavar/aletheia)
 
 ## Support
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update the Client Libraries section of our documentation page to
* Remove a defunct link to the .NET client
* Add a new Java and PHP client
* Reformat the list
* Sort alphabetically (because why not?)

## How to test

Tested locally

## How can we measure success?

Did the page appear as expected? Did the links work? Yes and yes? Success!

## Have we considered potential risks?

There's no risk here.

## Images

Before:
<img width="850" alt="Screenshot 2023-09-01 at 12 11 17" src="https://github.com/guardian/open-platform-site/assets/690395/e481f95d-1c44-4f6e-a24a-b89cdacbc325">

After:
<img width="850" alt="Screenshot 2023-09-01 at 12 10 42" src="https://github.com/guardian/open-platform-site/assets/690395/feb8a904-1c44-400c-9322-5d8ebe923d1d">

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)

