### PR TITLE
tiny bugfix to rights field doc

### DIFF
--- a/documentation/md/content_search.md
+++ b/documentation/md/content_search.md
@@ -68,7 +68,7 @@ Field  | Description | Type |  |
 | `reference`         | Return only content with those references          | *String*  | e.g. isbn/9780718178949                                     | true                   |
 | `reference-type`    | Return only content with references of those types | *String*  | e.g. isbn                                                   | true                   |
 | `tag`               | Return only content with those tags                | *String*  | e.g. technology/apple                                       | true                   |
-| `rights`            | Return only content with those rights              | *String*  | syndicatable \                                              | subscription-databases | false
+| `rights`            | Return only content with those rights              | *String*  | syndicatable, subscription-databases                        | false
 | `ids`               | Return only content with those IDs                 | *String*  | e.g. technology/2014/feb/17/flappy-bird-clones-apple-google | false                  |
 | `production-office` | Return only content from those production offices  | *String*  | e.g. aus                                                    | true                   |
 | `lang`              | Return only content in those languages             | *String*  | ISO language codes, e.g. en, fr                             | true                   |
@@ -86,7 +86,7 @@ Field  | Description | Type |  |
 | `use-date` | Changes which type of date is used to filter the results using `from-date` and `to-date` | *String* | See list below  |
 
 * `published` - The date the content has been last published  - __Default__
-* `first-publication` - The date the content has been first published 
+* `first-publication` - The date the content has been first published
 * `newspaper-edition` - The date the content appeared in print
 * `last-modified` - The date the content was last updated
 
@@ -235,8 +235,8 @@ Field  | Description | Type |  |
 
 
 
-          
- 
+
+
 
 
 


### PR DESCRIPTION
The row for the `rights` field in the [search documentation](https://open-platform.theguardian.com/documentation/search) looks weird:

<img width="969" alt="image" src="https://github.com/guardian/open-platform-site/assets/2242307/1b2bde01-9265-44d0-ac63-c52f21841654">

Seems like we tried to insert a `|` pipe char and escape it so it didn't break the table but that syntax seems to work. This fix just using a `,` instead.

<img width="969" alt="image" src="https://github.com/guardian/open-platform-site/assets/2242307/b4045432-6721-4cac-8933-670e850531f9">

