### PR TITLE
Document the content/next end point for deep pagination

### DIFF
--- a/documentation/md/content_search.md
+++ b/documentation/md/content_search.md
@@ -233,6 +233,160 @@ Field  | Description | Type |  |
 [https://content.guardianapis.com/search?q=12%20years%20a%20slave&format=json&tag=film/film,tone/reviews&from-date=2010-01-01&show-tags=contributor&show-fields=starRating,headline,thumbnail,short-url&show-refinements=all&order-by=relevance](https://content.guardianapis.com/search?q=12%20years%20a%20slave&format=json&tag=film/film,tone/reviews&from-date=2010-01-01&show-tags=contributor&show-fields=starRating,headline,thumbnail,short-url&order-by=relevance&api-key=test)
 
 
+## Deep pagination
+
+Page options (above) allow you to paginate through several thousand results using `page` and `pageSize`.
+There is a limit to how deep you can go using this approach.
+
+If your application needs to paginate beyond these limits you will need to use the content `/next` end point rather than page options.
+
+
+### Using the content /next end point
+
+Start your search using the `/search` end point.
+
+ie.
+`https://content.guardianapis.com/search?q=sausages&page-size-10&order-by=relevance`
+
+```
+{
+    "response": {
+        "status": "ok",
+        "total": 5857,
+        "startIndex": 1,
+        "pageSize": 10,
+        "currentPage": 1,
+        "pages": 586,
+        "orderBy": "relevance",
+        "results": [
+            {
+            "id": "food/2023/mar/22/how-to-make-glamorgan-sausages-recipe-felicity-cloake",
+            "type": "article",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webPublicationDate": "2023-03-22T12:00:26Z",
+            "webTitle": "How to make Glamorgan sausages | Felicity Cloake's Masterclas",
+            "webUrl": "https://www.theguardian.com/food/2023/mar/22/how-to-make-glamorgan-sausages-recipe-felicity-cloake",
+            "apiUrl": "https://content.guardianapis.com/food/2023/mar/22/how-to-make-glamorgan-sausages-recipe-felicity-cloake",
+            "isHosted": false,
+            "pillarId": "pillar/lifestyle",
+            "pillarName": "Lifestyle"
+            },
+            ... 8 results omitted ...
+            {
+            "id": "food/2022/jul/04/peperonata-sausages-recipe-rachel-roddy",
+            "type": "article",
+            "sectionId": "food",
+            "sectionName": "Food",
+            "webPublicationDate": "2022-07-04T10:00:40Z",
+            "webTitle": "Rachel Roddy’s recipe for peperonata with sausages | A kitchen in Rome",
+            "webUrl": "https://www.theguardian.com/food/2022/jul/04/peperonata-sausages-recipe-rachel-roddy",
+            "apiUrl": "https://content.guardianapis.com/food/2022/jul/04/peperonata-sausages-recipe-rachel-roddy",
+            "isHosted": false,
+            "pillarId": "pillar/lifestyle",
+            "pillarName": "Lifestyle"
+            }
+        ]
+    }
+}
+```
+
+Note the total, pages and currentPage values. These show you that there are more results than what is shown on the current page.
+
+Take the `id` of the last result. It is `food/2022/jul/04/peperonata-sausages-recipe-rachel-roddy` in this example.
+
+We can continue our pagination using the `/next` end point for this content item.
+
+Preserving your query parameters and ordering, call the content `/next` end point for the last piece of content seen:
+
+ie.
+`https://content.guardianapis.com/content/food/2022/jul/04/peperonata-sausages-recipe-rachel-roddy/next?q=sausages&page-size=10&order-by=relevance`
+
+```
+{
+    "response": {
+        "status": "ok",
+        "total": 5857,
+        "startIndex": 1,
+        "pageSize": 10,
+        "currentPage": 1,
+        "pages": 586,
+        "orderBy": "relevance",
+        "results": [
+            ... 9 results omitted ...
+            {
+                "id": "commentisfree/2022/jun/20/big-festivals-glastonbury-so-white-lenny-henry-lack-of-diversity-arts-culture",
+                "type": "article",
+                "sectionId": "commentisfree",
+                "sectionName": "Opinion",
+                "webPublicationDate": "2022-06-20T14:00:17Z",
+                "webTitle": "Why are big festivals like Glastonbury so white? | Stephanie Phillips",
+                "webUrl": "https://www.theguardian.com/commentisfree/2022/jun/20/big-festivals-glastonbury-so-white-lenny-henry-lack-of-diversity-arts-culture",
+                "apiUrl": "https://content.guardianapis.com/commentisfree/2022/jun/20/big-festivals-glastonbury-so-white-lenny-henry-lack-of-diversity-arts-culture",
+                "isHosted": false,
+                "pillarId": "pillar/opinion",
+                "pillarName": "Opinion"
+            }
+        ]
+    }
+}
+```
+
+Take the `id` of the last result and repeat:
+
+ie.
+`https://content.guardianapis.com/content/commentisfree/2022/jun/20/big-festivals-glastonbury-so-white-lenny-henry-lack-of-diversity-arts-culture/next?q=sausages&page-size=10&order-by=relevance`
+
+Continue iterating using the `id` of the last result seen.
+Eventually you will receive a response containing fewer results than the page size.
+
+ie.
+`https://content.guardianapis.com/content/film/1998/mar/23/features/next?q=sausages&page-size=10&order-by=relevance`
+
+```
+{
+    "response": {
+        "status": "ok",
+        "total": 5857,
+        "startIndex": 1,
+        "pageSize": 10,
+        "currentPage": 1,
+        "pages": 586,
+        "orderBy": "relevance",
+        "results": [
+            {
+            "id": "uk/1993/nov/04/bulger",
+            "type": "article",
+            "sectionId": "uk-news",
+            "sectionName": "UK news",
+            "webPublicationDate": "1993-11-04T13:16:14Z",
+            "webTitle": "Film 'shows boy lured to his death'",
+            "webUrl": "https://www.theguardian.com/uk/1993/nov/04/bulger",
+            "apiUrl": "https://content.guardianapis.com/uk/1993/nov/04/bulger",
+            "isHosted": false,
+            "pillarId": "pillar/news",
+            "pillarName": "News"
+            },
+            {
+            "id": "music/1992/jun/29/glastonbury2003.glastonbury",
+            "type": "article",
+            "sectionId": "music",
+            "sectionName": "Music",
+            "webPublicationDate": "1992-06-29T01:34:17Z",
+            "webTitle": "Access triumphs over excess",
+            "webUrl": "https://www.theguardian.com/music/1992/jun/29/glastonbury2003.glastonbury",
+            "apiUrl": "https://content.guardianapis.com/music/1992/jun/29/glastonbury2003.glastonbury",
+            "isHosted": false,
+            "pillarId": "pillar/arts",
+            "pillarName": "Arts"
+            }
+        ]
+    }
+}
+```
+
+This indicates that you have reached the end and can stop querying.
+
 
 
 


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Document the content /next end point and it's use in paginating beyond the limits of page options (page + pageSize) pagination.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
